### PR TITLE
Fix README RODBCext installation text

### DIFF
--- a/R/README.md
+++ b/R/README.md
@@ -6,7 +6,7 @@ sqlmlutils is an R package to help execute R code on a SQL Server machine.
 
 Run 
 ```
-R CMD INSTALL RODBCext
+R -e "install.packages('RODBCext', repos='https://cran.microsoft.com')"
 R CMD INSTALL dist/sqlmlutils_0.5.0.zip
 ```
 OR

--- a/R/buildandinstall.cmd
+++ b/R/buildandinstall.cmd
@@ -1,6 +1,6 @@
 pushd .
 cd ..
-R -e "install.packages('RODBCext', repos='https://cran.rstudio.com')"
+R -e "install.packages('RODBCext', repos='https://cran.microsoft.com')"
 R CMD INSTALL --build R
 mv sqlmlutils_0.5.0.zip R/dist
 popd


### PR DESCRIPTION
Don't use R CMD INSTALL for RODBCext, use cran.microsoft.com with install.packages