### PR TITLE
Add a check to dependency packages to install

### DIFF
--- a/R/R/sqlPackage.R
+++ b/R/R/sqlPackage.R
@@ -1097,6 +1097,11 @@ prunePackagesToInstallExtLib <- function(dependentPackages, topMostPackages, ins
     prunedPackagesToInstall <- NULL
     prunedPackagesToTop <- NULL
 
+    if (is.null(dependentPackages))
+    {
+        return(list(NULL, NULL))
+    }
+
     for (pkgToInstallIndex in 1:nrow(dependentPackages))
     {
         pkgToInstall <- dependentPackages[pkgToInstallIndex,]

--- a/R/tests/testthat/test.sqlPackage.dependencies.R
+++ b/R/tests/testthat/test.sqlPackage.dependencies.R
@@ -122,7 +122,7 @@ test_that( "Installing a package that is already in use", {
 
     packageName <- c("lattice") # usually already attached in a R session.
 
-    installedPackages <- sql_installed.packages(connectionString, fields = NULL, scope = scope, owner =  owner)
+    installedPackages <- sql_installed.packages(connectionString, fields = NULL, scope = scope)
     if (!packageName %in% installedPackages)
     {
         sql_install.packages(connectionStringAirlineUserdbowner, packageName, verbose = TRUE, scope = scope)

--- a/R/tests/testthat/test.sqlPackage.dependencies.R
+++ b/R/tests/testthat/test.sqlPackage.dependencies.R
@@ -132,5 +132,5 @@ test_that( "Installing a package that is already in use", {
     # install the package again and check if it fails with the correct message.
     #
     output <- capture.output(sql_install.packages( connectionStringAirlineUserdbowner, packageName, verbose = TRUE, scope = scope))
-    expect_true((grepl("already installed", output)))
+    expect_true(TRUE %in% (grepl("already installed", output)))
 })

--- a/R/tests/testthat/test.sqlPackage.dependencies.R
+++ b/R/tests/testthat/test.sqlPackage.dependencies.R
@@ -119,12 +119,18 @@ test_that( "Installing a package that is already in use", {
     cat("\nINFO: checking remote lib paths...\n")
     helper_checkSqlLibPaths(connectionStringAirlineUserdbowner, 1)
 
-    packageName <- c("lattice") # by default already attached in a R session.
+
+    packageName <- c("lattice") # usually already attached in a R session.
+
+    installedPackages <- sql_installed.packages(connectionString, fields = NULL, scope = scope, owner =  owner)
+    if (!packageName %in% installedPackages)
+    {
+        sql_install.packages(connectionStringAirlineUserdbowner, packageName, verbose = TRUE, scope = scope)
+    }
 
     #
-    # install the package with its dependencies and check if its present
+    # install the package again and check if it fails with the correct message.
     #
     output <- capture.output(sql_install.packages( connectionStringAirlineUserdbowner, packageName, verbose = TRUE, scope = scope))
-    print(output)
     expect_true((grepl("already installed", output)))
 })

--- a/R/tests/testthat/test.sqlPackage.dependencies.R
+++ b/R/tests/testthat/test.sqlPackage.dependencies.R
@@ -122,7 +122,7 @@ test_that( "Installing a package that is already in use", {
 
     packageName <- c("lattice") # usually already attached in a R session.
 
-    installedPackages <- sql_installed.packages(connectionString, fields = NULL, scope = scope)
+    installedPackages <- sql_installed.packages(connectionStringAirlineUserdbowner, fields = NULL, scope = scope)
     if (!packageName %in% installedPackages)
     {
         sql_install.packages(connectionStringAirlineUserdbowner, packageName, verbose = TRUE, scope = scope)

--- a/R/tests/testthat/test.sqlPackage.dependencies.R
+++ b/R/tests/testthat/test.sqlPackage.dependencies.R
@@ -107,3 +107,24 @@ test_that( "package install and uninstall with dependency", {
     helper_checkPackageStatusRequire( connectionStringAirlineUserdbowner, packageName, FALSE)
     helper_checkPackageStatusRequire( connectionStringAirlineUserdbowner, dependentPackageName, FALSE)
 })
+
+test_that( "Installing a package that is already in use", {
+    #skip("temporaly_disabled")
+    connectionStringAirlineUserdbowner <- helper_getSetting("connectionStringAirlineUserdbowner")
+    scope <- "private"
+
+    #
+    # check package management is installed
+    #
+    cat("\nINFO: checking remote lib paths...\n")
+    helper_checkSqlLibPaths(connectionStringAirlineUserdbowner, 1)
+
+    packageName <- c("lattice") # by default already attached in a R session.
+
+    #
+    # install the package with its dependencies and check if its present
+    #
+    output <- capture.output(sql_install.packages( connectionStringAirlineUserdbowner, packageName, verbose = TRUE, scope = scope))
+    print(output)
+    expect_true((grepl("already installed", output)))
+})


### PR DESCRIPTION
Add a check so that if people try to install a package that is already attached or have no dependency package, it'd not error out and the message would be more clear (Packages <…> already installed).
Issue #29  