### PR TITLE
Fix R Unit Tests and Invalid Cursor State Occurrences

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r-version: ["3.5.2"]
+        r-version: ["3.5.2", "4.2"]
 
     env:
       # Define CI to skip some test case.
@@ -58,7 +58,7 @@ jobs:
             #Updated odbc pkg is still compatible with R >= 3.2.0
             cran::odbc
             rcmdcheck
-          
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           working-directory: ./R

--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sqlmlutils
 Type: Package
 Title: Wraps R code into executable SQL Server stored procedures
-Version: 1.1.0
+Version: 1.2.1
 Author: Microsoft Corporation
 Maintainer: Microsoft Corporation <msrpack@microsoft.com>
 Depends:
@@ -13,7 +13,7 @@ Description: sqlmlutils is a package designed to help users interact with SQL Se
              creating and running stored procedures, and managing packages on the database.
 License: MIT + file LICENSE
 Copyright: Copyright 2016 Microsoft Corporation
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.2
 Encoding: UTF-8
 Suggests: testthat (>= 2.0.0),
     roxygen2

--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sqlmlutils
 Type: Package
 Title: Wraps R code into executable SQL Server stored procedures
-Version: 1.0.0
+Version: 1.1.0
 Author: Microsoft Corporation
 Maintainer: Microsoft Corporation <msrpack@microsoft.com>
 Depends:

--- a/R/R/executeInSQL.R
+++ b/R/R/executeInSQL.R
@@ -39,7 +39,7 @@ connectionInfo <- function(driver = "SQL Server", server = "localhost", database
         }
         else
         {
-            authorization = sprintf("uid=%s;pwd=%s",uid,pwd)
+            authorization = sprintf("uid=%s;pwd={%s}",uid,pwd)
         }
     }
 

--- a/R/R/sqlPackage.R
+++ b/R/R/sqlPackage.R
@@ -474,10 +474,14 @@ sqlRemoteExecuteFun <- function(connection, FUN, ..., useRemoteFun = FALSE, asus
         query <- paste0("EXECUTE AS USER = '", asuser, "';")
     }
 
+    # Addresses Invalid Cursor State issue triggered by PRINT() statements
+    # and DIAG messages from SQL Server.
+    resultSet <- "WITH RESULT SETS((resultColumn varchar(MAX)))"
     query <- paste0(query
                     ,"\nEXEC sp_execute_external_script"
                     ,"\n@language = N'", languageName, "'"
-                    ,"\n,@script = N'",script, "';"
+                    ,"\n,@script = N'",script, "'"
+                    ,"\n",resultSet, ";"
     )
 
     if (!is.null(asuser))

--- a/R/R/sqlPackage.R
+++ b/R/R/sqlPackage.R
@@ -1173,8 +1173,11 @@ getDependentPackagesToInstall <- function(pkgs, availablePackages, installedPack
 
         #
         # Determine if package is available as a binary package
+        # Utilize first of possibly many contributor URLs present
+        # in character vector contribWinBinaryUrl
         #
-        packageProperties <- availablePackages[availablePackages$Package == package & availablePackages$Repository == contribWinBinaryUrl, ]
+        contributorURL <- contribWinBinaryUrl[1]
+        packageProperties <- availablePackages[availablePackages$Package == package & availablePackages$Repository == contributorURL, ]
 
         #
         # When only a source package is available, add LinkingTo dependencies

--- a/R/R/sqlPackage.R
+++ b/R/R/sqlPackage.R
@@ -818,7 +818,7 @@ sqlCheckPackageManagementVersion <- function(connectionString)
 
     version <- sqlPackageManagementVersion(connectionString)
 
-    if (is.null(version) || is.na(version) || length(version) == 0)
+    if (is.null(version) || any(is.na(version)) || length(version) == 0)
     {
         stop("Invalid SQL version is null or empty", call. = FALSE)
     }

--- a/R/tests/testthat/helper-Setup.R
+++ b/R/tests/testthat/helper-Setup.R
@@ -51,7 +51,7 @@ testthatDir <- getwd()
 R_Root <- file.path(testthatDir, "../..")
 scriptDirectory <- file.path(testthatDir, "scripts")
 
-options(repos = c(CRAN="https://cran.microsoft.com", CRANextra = "https://mran.microsoft.com/snapshot/2019-02-01"))
+options(repos = c(CRAN="https://cran.microsoft.com/snapshot/2022-07-06"))
 cat("INFO: repos = ", getOption("repos"), sep="\n")
 
 # Compute context specifications

--- a/R/tests/testthat/test.executeInSqlTests.R
+++ b/R/tests/testthat/test.executeInSqlTests.R
@@ -93,7 +93,8 @@ test_that("Returning a function object",
         return(func2)
     }
 
-    expect_equal(executeFunctionInSQL(connection, func=func1), func2)
+    # Result of executeFunctionInSQL() will have different environment than func2.
+    expect_equal(executeFunctionInSQL(connection, func=func1), func2, check.environment=FALSE)
 })
 
 test_that("Calling an object in the environment",

--- a/R/tests/testthat/test.sqlPackage.unit.R
+++ b/R/tests/testthat/test.sqlPackage.unit.R
@@ -24,7 +24,7 @@ test_that("Package management ExtLib", {
 })
 
 test_that("GetServerVersion() Returns Server Version of R Successfully",{
-    version <- sqlmlutils:::getserverVersion(connectionString = cnnstr, languageName = "R")
-    # rversion var truncated, so R may be >= 3.5 (3.5.3) or >= 4.2
-    expect_gte(as.double(version[['rversion']]), 3.5)
+    rversion <- sqlmlutils:::getserverVersion(connectionString = cnnstr, languageName = "R")
+    # rversion value truncated, so R may be >= 3.5 (3.5.3) or >= 4.2
+    expect_gte(as.double(rversion[['rversion']]), 3.5)
 })

--- a/R/tests/testthat/test.sqlPackage.unit.R
+++ b/R/tests/testthat/test.sqlPackage.unit.R
@@ -22,3 +22,9 @@ test_that("Package management ExtLib", {
     versionClass <- sqlmlutils:::sqlCheckPackageManagementVersion(connectionString = helper_getSetting("connectionStringDBO"))
     expect_equal(versionClass, "ExtLib")
 })
+
+test_that("GetServerVersion() Returns Server Version of R Successfully",{
+    version <- sqlmlutils:::getserverVersion(connectionString = cnnstr, languageName = "R")
+    # rversion var truncated, so R may be >= 3.5 (3.5.3) or >= 4.2
+    expect_gte(as.double(version[['rversion']]), 3.5)
+})


### PR DESCRIPTION
# Why is this change being made?

This change enables compatibility with R 4.2, which consequently introduces support for SQL Server 2022 starting with CTP2.0. Additionally, the fix for certain queries experiencing the error `Invalid cursor state` is included.

# What does this change do?

- Due to [changes introduced in R 4.2](https://cran.r-project.org/doc/manuals/r-release.save/NEWS.html)[1], warnings like `length(x) = 5 > 1' in coercion to 'logical(1)'` were surfacing. This was fixed with corrected conditional logic. 
  - Old
`if (is.null(version) || is.na(version) || length(version) == 0)`, the variable `version` is a vector of count > 1.
  - New
`if (is.null(version) || any(is.na(version)) || length(version) == 0)`, uses `any()` to determine, given a set of logical vectors, that at least one of the values is true.

- In [test.executeInSqlTests.R](https://github.com/microsoft/sqlmlutils/commit/ac1f97b15e8361e76ed39c05333f79c0a7c08f9e#diff-4795e443a30bdbc2fb1f7fedfa761037fa6fca825b641d70a9365c029236081f) the test _Returning a function object_ was checking that execution of a function in SQL Server would return the function result matching that defined locally. In order for this check to succeed based on equality of the function content, the optional parameter `check.environment=FALSE` is passed to test_that's `expect_equal` [which behind the scenes](https://cran.r-project.org/web/packages/testthat/testthat.pdf#page=8&zoom=100,0,0) uses [base::identical()](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/identical) to ignore the environment differences that are present because the function objects were created in different R environments (client/server).

- Add support for special characters in the connection string password for test_that tests by escaping the pwd attribute value with curly braces. [SQL Server ODBC Doc Reference](https://docs.microsoft.com/en-us/sql/relational-databases/native-client/applications/using-connection-string-keywords-with-sql-server-native-client?view=sql-server-ver16#odbc-driver-connection-string-keywords)

- Remediates instances of the error `cursor state invalid` experience in certain commands due to the `getServerVersion()` function not utilizing the T-SQL execution option `WITH RESULT SETS`. Due to underlying behavior of the utilized ODBC drivers, the execution option is necessary to ensure a result set is properly parsed by the driver interface code. The fix adds the execution option to the relevant code path.

- Fixes warning `longer object length is not a multiple of shorter object length` that appeared due to an object not guaranteed to be of size 1.
  - `packageProperties <- availablePackages[availablePackages$Package == package & availablePackages$Repository == contributorURL, ]` where `contributorURL` is assigned the first element of the previously compared object `contribWinBinaryUrl`. More than one URL may be present if the SQLMLUtils environment is unexpectedly set with more than one repository source using `options(repos='xx')`.
  
# How is this change tested?
- [x] Pass all existing unit tests
- [x] Added unit test to explicitly run `checkServerVersion()` to validate that the `Cursor State Invalide` error is not encountered. 

# References
[[1](https://cran.r-project.org/doc/manuals/r-release.save/NEWS.html)] - Changes in R4.2 

> Calling && or || with either argument of length greater than one now gives a warning (which it is intended will become an error).
> 
> Calling if() or while() with a condition of length greater than one gives an error rather than a warning. Consequently, environment variable _R_CHECK_LENGTH_1_CONDITION_ no longer has any effect.
