### PR TITLE
Migrate Pipeline to Self-Hosted Runners and Remediate Tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,6 @@ env:
   PASSWORD_AIRLINE_USER: ${{ secrets.PASSWORD_AIRLINE_USER }}
   PASSWORD_AIRLINE_USER_DBOWNER: ${{ secrets.PASSWORD_AIRLINE_USER_DBOWNER }}
   DRIVER: "{ODBC Driver 17 for SQL Server}"
-  SQL2019SERVER: ${{ secrets.SQL19SERVER }}
-  SQL2022SERVER: ${{ secrets.SQL22SERVER }}
 
 jobs:
   R:
@@ -50,18 +48,10 @@ jobs:
         run: echo SERVER=${{ secrets.SQL19SERVER }}>> %GITHUB_ENV%
         shell: cmd
 
-      - name: Set SQL MI Env_var for R 3.5.3
-        if: matrix.sql-platform == 'MI'
-        run: echo SERVER=${{ secrets.SQLMISERVER }}>> %GITHUB_ENV%
-        shell: cmd
-
       - name: Set SQL Server 2022 Env_var for R 4.2.0
         if: matrix.r-version == '4.2.0'
         run: echo SERVER=${{ secrets.SQL22SERVER }}>> %GITHUB_ENV%
         shell: cmd
-
-      - name: check env
-        run: env
 
       - name: Check Database Connectivity to SQL Database
         run: |
@@ -98,12 +88,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7.1, 3.10.5]
         include:
           - python-version: "3.7.1"
             sql-platform: "box"
-          - python-version: "3.7.1"
-            sql-platform: "MI"
           - python-version: "3.10.5"
             sql-platform: "box"
 
@@ -114,27 +101,18 @@ jobs:
     steps:
     - name: Set SQL Server 2019 Env_var for Python 3.7.1
       if: matrix.python-version == '3.7.1'
-      run: echo SERVER=${{ secrets.SQL19SERVER }} >> %GITHUB_ENV%
+      run: echo SERVER=${{ secrets.SQL19SERVER }}>> %GITHUB_ENV%
       shell: cmd
 
     - name: Set SQL Server 2022 Env_var for Python 3.10.5
       if: matrix.python-version == '3.10.5'
-      run: echo SERVER=${{ secrets.SQL22SERVER }} >> %GITHUB_ENV%
+      run: echo SERVER=${{ secrets.SQL22SERVER }}>> %GITHUB_ENV%
       shell: cmd
 
-    - name: check env
-      run: env
-
-    - name: Check Database Connectivity SQL Server 2019
+    - name: Check Database Connectivity SQL Database
       if: matrix.python-version == '3.7.1'
       run: |
-        sqlcmd -S tcp:${{ secrets.SQL19SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
-      shell: cmd
-
-    - name: Check Database Connectivity SQL Server 2022
-      if: matrix.python-version == '3.10.5'
-      run: |
-        sqlcmd -S tcp:${{ secrets.SQL22SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
+        sqlcmd -S tcp:%SERVER%,1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
       shell: cmd
 
     - name: Checkout Branch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,6 @@ jobs:
         run: |
           sqlcmd -S tcp:%SERVER%,1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
         shell: cmd
-        continue-on-error: true
 
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - r-version: "3.5.3"
+          - r-version: "3.5.2"
             sql-platform: "box"
           - r-version: "4.2.0"
             sql-platform: "box"
@@ -43,8 +43,8 @@ jobs:
         shell: cmd
 
     steps:
-      - name: Set SQL Server 2019 Env_var for R 3.5.3
-        if: matrix.r-version == '3.5.3' && matrix.sql-platform == 'box'
+      - name: Set SQL Server 2019 Env_var for R 3.5.2
+        if: matrix.r-version == '3.5.2' && matrix.sql-platform == 'box'
         run: echo SERVER=${{ secrets.SQL19SERVER }}>> %GITHUB_ENV%
         shell: cmd
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,12 +29,9 @@ jobs:
     runs-on: [self-hosted, 1ES.Pool=sqlmlutils_GH_RunnerPool]
     strategy:
       matrix:
-        r-version: ["3.5.3", "4.2.0"]
         include:
           - r-version: "3.5.3"
             sql-platform: "box"
-          - r-version: "3.5.3"
-            sql-platform: "MI"
           - r-version: "4.2.0"
             sql-platform: "box"
 
@@ -50,40 +47,25 @@ jobs:
     steps:
       - name: Set SQL Server 2019 Env_var for R 3.5.3
         if: matrix.sql-platform == 'box'
-        run: echo SERVER=${{ secrets.SQL19SERVER }} >> %GITHUB_ENV%
+        run: echo SERVER=${{ secrets.SQL19SERVER }}>> %GITHUB_ENV%
         shell: cmd
 
       - name: Set SQL MI Env_var for R 3.5.3
         if: matrix.sql-platform == 'MI'
-        run: echo SERVER=${{ secrets.SQLMISERVER }} >> %GITHUB_ENV%
+        run: echo SERVER=${{ secrets.SQLMISERVER }}>> %GITHUB_ENV%
         shell: cmd
 
       - name: Set SQL Server 2022 Env_var for R 4.2.0
         if: matrix.r-version == '4.2.0'
-        run: echo SERVER=${{ secrets.SQL22SERVER }} >> %GITHUB_ENV%
+        run: echo SERVER=${{ secrets.SQL22SERVER }}>> %GITHUB_ENV%
         shell: cmd
 
       - name: check env
         run: env
 
-      - name: Check Database Connectivity SQL Server 2019
-        if: matrix.r-version == '3.5.3' && matrix.sql-platform == 'box'
-        run: |
-          sqlcmd -S tcp:${{ env.SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
-        shell: cmd
-        continue-on-error: true
-
-      - name: Check Database Connectivity SQL MI
-        if: matrix.r-version == '3.5.3' && matrix.sql-platform == 'MI'
+      - name: Check Database Connectivity to SQL Database
         run: |
           sqlcmd -S tcp:%SERVER%,1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
-        shell: cmd
-        continue-on-error: true
-
-      - name: Check Database Connectivity SQL Server 2022
-        if: matrix.r-version == '4.2.0' && matrix.sql-platform == 'box'
-        run: |
-          sqlcmd -S tcp:${{ env.SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
         shell: cmd
         continue-on-error: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,17 @@ env:
 
 jobs:
   R:
-    runs-on:  [self-hosted, 1ES.Pool=sqlmlutils_GH_RunnerPool]
+    runs-on: [self-hosted, 1ES.Pool=sqlmlutils_GH_RunnerPool]
     strategy:
       matrix:
         r-version: ["3.5.3", "4.2.0"]
+        include:
+          - r-version: "3.5.3"
+            sql-platform: "box"
+          - r-version: "3.5.3"
+            sql-platform: "MI"
+          - r-version: "4.2.0"
+            sql-platform: "box"
 
     env:
       # Define CI to skip some test case.
@@ -42,8 +49,13 @@ jobs:
 
     steps:
       - name: Set SQL Server 2019 Env_var for R 3.5.3
-        if: matrix.r-version == '3.5.3'
+        if: matrix.sql-platform == 'box'
         run: echo SERVER=${{ secrets.SQL19SERVER }} >> %GITHUB_ENV%
+        shell: cmd
+
+      - name: Set SQL MI Env_var for R 3.5.3
+        if: matrix.sql-platform == 'MI'
+        run: echo SERVER=${{ secrets.SQLMISERVER }} >> %GITHUB_ENV%
         shell: cmd
 
       - name: Set SQL Server 2022 Env_var for R 4.2.0
@@ -55,16 +67,25 @@ jobs:
         run: env
 
       - name: Check Database Connectivity SQL Server 2019
-        if: matrix.r-version == '3.7.1'
+        if: matrix.r-version == '3.5.3' && matrix.sql-platform == 'box'
         run: |
-          sqlcmd -S tcp:${{ secrets.SQL19SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
+          sqlcmd -S tcp:${{ env.SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
         shell: cmd
+        continue-on-error: true
+
+      - name: Check Database Connectivity SQL MI
+        if: matrix.r-version == '3.5.3' && matrix.sql-platform == 'MI'
+        run: |
+          sqlcmd -S tcp:%SERVER%,1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
+        shell: cmd
+        continue-on-error: true
 
       - name: Check Database Connectivity SQL Server 2022
-        if: matrix.r-version == '3.10.5'
+        if: matrix.r-version == '4.2.0' && matrix.sql-platform == 'box'
         run: |
-          sqlcmd -S tcp:${{ secrets.SQL22SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
+          sqlcmd -S tcp:${{ env.SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
         shell: cmd
+        continue-on-error: true
 
       - name: Checkout Branch
         uses: actions/checkout@v2
@@ -96,6 +117,13 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [3.7.1, 3.10.5]
+        include:
+          - python-version: "3.7.1"
+            sql-platform: "box"
+          - python-version: "3.7.1"
+            sql-platform: "MI"
+          - python-version: "3.10.5"
+            sql-platform: "box"
 
     env:
       CI: True

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,20 +16,20 @@ on:
   workflow_dispatch:
 
 env:
-  SERVER: ${{ secrets.SERVER }}
   USER: ${{ secrets.USER }}
   PASSWORD: ${{ secrets.PASSWORD }}
   PASSWORD_AIRLINE_USER: ${{ secrets.PASSWORD_AIRLINE_USER }}
   PASSWORD_AIRLINE_USER_DBOWNER: ${{ secrets.PASSWORD_AIRLINE_USER_DBOWNER }}
   DRIVER: "{ODBC Driver 17 for SQL Server}"
+  SQL2019SERVER: ${{ secrets.SQL19SERVER }}
+  SQL2022SERVER: ${{ secrets.SQL22SERVER }}
 
 jobs:
   R:
-    runs-on: windows-latest
+    runs-on:  [self-hosted, 1ES.Pool=sqlmlutils_GH_RunnerPool]
     strategy:
-      fail-fast: false
       matrix:
-        r-version: ["3.5.2", "4.2"]
+        r-version: ["3.5.3", "4.2.0"]
 
     env:
       # Define CI to skip some test case.
@@ -38,10 +38,36 @@ jobs:
 
     defaults:
       run:
-        working-directory: ./R
+        shell: cmd
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Set SQL Server 2019 Env_var for R 3.5.3
+        if: matrix.r-version == '3.5.3'
+        run: echo SERVER=${{ secrets.SQL19SERVER }} >> %GITHUB_ENV%
+        shell: cmd
+
+      - name: Set SQL Server 2022 Env_var for R 4.2.0
+        if: matrix.r-version == '4.2.0'
+        run: echo SERVER=${{ secrets.SQL22SERVER }} >> %GITHUB_ENV%
+        shell: cmd
+
+      - name: check env
+        run: env
+
+      - name: Check Database Connectivity SQL Server 2019
+        if: matrix.r-version == '3.7.1'
+        run: |
+          sqlcmd -S tcp:${{ secrets.SQL19SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
+        shell: cmd
+
+      - name: Check Database Connectivity SQL Server 2022
+        if: matrix.r-version == '3.10.5'
+        run: |
+          sqlcmd -S tcp:${{ secrets.SQL22SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
+        shell: cmd
+
+      - name: Checkout Branch
+        uses: actions/checkout@v2
 
       - name: Set up R ${{ matrix.r-version }} Runtime
         uses: r-lib/actions/setup-r@v2
@@ -57,6 +83,7 @@ jobs:
             #Retrieves most recent odbc pkg from cran to avoid errors seen in older versions.
             #Updated odbc pkg is still compatible with R >= 3.2.0
             cran::odbc
+            cran::xml2
             rcmdcheck
 
       - uses: r-lib/actions/check-r-package@v2
@@ -64,31 +91,62 @@ jobs:
           working-directory: ./R
 
   Python:
-    runs-on: windows-latest
+    runs-on:  [self-hosted, 1ES.Pool=sqlmlutils_GH_RunnerPool]
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        python-version: [3.7]
+        python-version: [3.7.1, 3.10.5]
 
     env:
-      DATABASE: ${{ secrets.DATABASE }}_Python
+      CI: True
+      DATABASE: ${{ secrets.DATABASE_PYTHON }}
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Set SQL Server 2019 Env_var for Python 3.7.1
+      if: matrix.python-version == '3.7.1'
+      run: echo SERVER=${{ secrets.SQL19SERVER }} >> %GITHUB_ENV%
+      shell: cmd
+
+    - name: Set SQL Server 2022 Env_var for Python 3.10.5
+      if: matrix.python-version == '3.10.5'
+      run: echo SERVER=${{ secrets.SQL22SERVER }} >> %GITHUB_ENV%
+      shell: cmd
+
+    - name: check env
+      run: env
+
+    - name: Check Database Connectivity SQL Server 2019
+      if: matrix.python-version == '3.7.1'
+      run: |
+        sqlcmd -S tcp:${{ secrets.SQL19SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
+      shell: cmd
+
+    - name: Check Database Connectivity SQL Server 2022
+      if: matrix.python-version == '3.10.5'
+      run: |
+        sqlcmd -S tcp:${{ secrets.SQL22SERVER }},1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
+      shell: cmd
+
+    - name: Checkout Branch
+      uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       working-directory: ./Python
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         pip install -r requirements.txt
-    - name: Run build script
+
+    - name: Build Python Package
       working-directory: ./Python
       run: ./buildandinstall.cmd
-    - name: Test with pytest
+
+    - name: Run pytest
       working-directory: ./Python/tests
       run: |
         pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,12 +44,12 @@ jobs:
 
     steps:
       - name: Set SQL Server 2019 Env_var for R 3.5.3
-        if: matrix.sql-platform == 'box'
+        if: matrix.r-version == '3.5.3' && matrix.sql-platform == 'box'
         run: echo SERVER=${{ secrets.SQL19SERVER }}>> %GITHUB_ENV%
         shell: cmd
 
       - name: Set SQL Server 2022 Env_var for R 4.2.0
-        if: matrix.r-version == '4.2.0'
+        if: matrix.r-version == '4.2.0' && matrix.sql-platform == 'box'
         run: echo SERVER=${{ secrets.SQL22SERVER }}>> %GITHUB_ENV%
         shell: cmd
 
@@ -100,12 +100,12 @@ jobs:
 
     steps:
     - name: Set SQL Server 2019 Env_var for Python 3.7.1
-      if: matrix.python-version == '3.7.1'
+      if: matrix.python-version == '3.7.1' && matrix.sql-platform == 'box'
       run: echo SERVER=${{ secrets.SQL19SERVER }}>> %GITHUB_ENV%
       shell: cmd
 
     - name: Set SQL Server 2022 Env_var for Python 3.10.5
-      if: matrix.python-version == '3.10.5'
+      if: matrix.python-version == '3.10.5' && matrix.sql-platform == 'box'
       run: echo SERVER=${{ secrets.SQL22SERVER }}>> %GITHUB_ENV%
       shell: cmd
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,6 @@ jobs:
       shell: cmd
 
     - name: Check Database Connectivity SQL Database
-      if: matrix.python-version == '3.7.1'
       run: |
         sqlcmd -S tcp:%SERVER%,1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
       shell: cmd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         run: echo SERVER=${{ secrets.SQL22SERVER }}>> %GITHUB_ENV%
         shell: cmd
 
-      - name: Check Database Connectivity to SQL Database
+      - name: Check Connectivity to SQL Database
         run: |
           sqlcmd -S tcp:%SERVER%,1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
         shell: cmd
@@ -108,7 +108,7 @@ jobs:
       run: echo SERVER=${{ secrets.SQL22SERVER }}>> %GITHUB_ENV%
       shell: cmd
 
-    - name: Check Database Connectivity SQL Database
+    - name: Check Connectivity SQL Database
       run: |
         sqlcmd -S tcp:%SERVER%,1433 -U %USER% -P %PASSWORD% -d %DATABASE% -l 5 -Q "SELECT @@VERSION"
       shell: cmd

--- a/Python/tests/package_management_pypi_test.py
+++ b/Python/tests/package_management_pypi_test.py
@@ -105,7 +105,6 @@ def test_dependency_resolution():
     finally:
         _drop_all_ddl_packages(connection, scope)
 
-@pytest.mark.skipif(sys.platform.startswith("linux"), reason="Slow test, don't run on Travis-CI, which uses Linux")
 def test_no_upgrade_parameter():
     """Test new version but no "upgrade" installation parameter"""
     try:
@@ -142,7 +141,6 @@ def test_no_upgrade_parameter():
     finally:
         _drop_all_ddl_packages(connection, scope)
 
-@pytest.mark.skipif(sys.platform.startswith("linux"), reason="Slow test, don't run on Travis-CI, which uses Linux")
 def test_upgrade_parameter():
     """Test the "upgrade" installation parameter"""
     try:
@@ -179,7 +177,7 @@ def test_upgrade_parameter():
     finally:
         _drop_all_ddl_packages(connection, scope)
 
-@pytest.mark.skipif(sys.platform.startswith("linux"), reason="Slow test, don't run on Travis-CI, which uses Linux")
+@pytest.mark.skip(reason="Very slow test. Skip for CI.")
 def test_already_installed_popular_ml_packages():
     """Test packages that are preinstalled, make sure they do not install anything extra"""
     installedpackages = ["numpy", "scipy", "pandas"]
@@ -190,7 +188,6 @@ def test_already_installed_popular_ml_packages():
         newsqlpkgs = _get_sql_package_table(connection)
         assert len(sqlpkgs) == len(newsqlpkgs)
 
-@pytest.mark.skipif(sys.platform.startswith("linux"), reason="Slow test, don't run on Travis-CI, which uses Linux")
 def test_dependency_spec():
     """Test that the DepedencyResolver handles ~= requirement spec.
     Also tests when package name and module name are different."""
@@ -225,7 +222,6 @@ def test_dependency_spec():
     finally:
         _drop_all_ddl_packages(connection, scope)
 
-@pytest.mark.skipif(sys.platform.startswith("linux"), reason="Slow test, don't run on Travis-CI, which uses Linux")
 def test_installing_popular_ml_packages():
     """Test a couple of popular ML packages"""
     newpackages = [ {'package': "TextBlob==0.17.1", 'module': 'textblob'}, {'package': "vocabulary==1.0.4", 'module': 'vocabulary'}]

--- a/R/R/sqlPackage.R
+++ b/R/R/sqlPackage.R
@@ -641,7 +641,7 @@ processInstalledPackagesResult <- function(result, fields)
         result <- result[, fields, drop = FALSE]
     }
 
-    if ((!is.null(fields)) && ((fields == "Package") && is.null(dim(result))))
+    if ((!is.null(fields)) && (any(fields == "Package") && is.null(dim(result))))
     {
         names(result) <- NULL
     }


### PR DESCRIPTION
## Why this change?

In order to fulfill internal compliance requirements, the GitHub Actions pipeline needs to be updated to utilize self-hosted runners, not GitHub default runners.

By using compliant self-hosted runners, we can now run tests that have full connectivity to our test servers: SQL Server 2019 and SQL Server 2022.

## What is this change?

### .github/workflows/ci.yaml

To utlize compliant self-hosted runners, the key `runs-on` was updated to `[self-hosted, 1ES.Pool=sqlmlutils_GH_RunnerPool]`.

The key `matrix` was updated to accommodate various versions of R and Python running on SQL Server 2019 and SQL Server 2022.
  - Based on the matrix combination, conditional job steps set the `SERVER` environment variable with the connection string of the target database using the syntax noted in [GitHub Action Workflow Syntax](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable).
  ``` shell
  echo SERVER=${{ secrets.SQLXXSERVER }}>> %GITHUB_ENV%
  ```
  Note: Take care not to leave any spaces between the last `}` and the `>>` because extra white space will result in incorrect connection string generation in the connectivity validation steps.

  A new key/value pair `cran::xml2` was added to the `r-lib/actions/setup-r@v2` step which pulls the latest CRAN version of the R package. The addition of this key/value pair mitigates the error: `Error: Error: <callr_remote_error: cannot open the connection> ` surfaced when running tests on R 3.5.3. The source link resolved for `xml2` version 1.3.2 was a dead link, thus failing dependency resolution.

  The `r-version` number was updated to explicitly use R 4.2.0. When the value is just 4.2, the latest point release will be chosen, which would now by 4.2.1. This surfaced an R error explained later.

### Python/tests/package_management_pypi_test.py

Removal of legacy conditional pytest markers which skipped tests when running on the previous Travis CI test runners on Linux.

Addition of conditional to skip Python test `test_already_installed_popular_ml_packages()` which is extremely slow on CI, possibly due to package dependency resolution.

### R/R/sqlPackage.R

An additional instance of the error `length > 1 in coercion to 'logical(1)'` surfaced when testing this change on R 4.2.1 as noted above. R 4.2.0 does not fail by design, but this fix cleans up code usage to adhere to requirements of the newest versions of R.

Per the latest [R Release Notes](https://cran.r-project.org/doc/manuals/r-devel/NEWS.html):

> Calling && or || with LHS or (if evaluated) RHS of length greater than one is now always an error, with a report of the form
> 
>     'length = 4' in coercion to 'logical(1)'

## How was this tested?

- [x] Pipeline tests now run and pass on SQL Server 2019 ( R 3.5.3 ) and (Python 3.7.1) and SQL Server 2022 CTP 2.0+  (R 4.2.0) and (Python 3.10.5).