### PR TITLE
Dev/seleonar/r packagename parsing

### DIFF
--- a/R/R/sqlPackage.R
+++ b/R/R/sqlPackage.R
@@ -1778,6 +1778,8 @@ enumeratePackagesFromFilePaths <- function(pkgs, topMostPackageFlag)
             Attribute = topMostPackageFlag,
             stringsAsFactors = FALSE))
     }
+
+    return (packages)
 }
 
 #

--- a/R/tests/testthat/test.sqlPackage.fileNameParse.unit.R
+++ b/R/tests/testthat/test.sqlPackage.fileNameParse.unit.R
@@ -1,0 +1,38 @@
+# Copyright(c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+library(sqlmlutils)
+library(testthat)
+
+context("Tests for sqlmlutils package management file path parsing helpers")
+
+#
+# A package name "should contain only (ASCII) letters, numbers and dot, have at least two
+# characters and start with a letter and not end in a dot.
+# Source: https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#The-DESCRIPTION-file
+# Consequentially, this test ensures that the parsed package name are the characters
+# that appear before the first underscore (_)
+#
+test_that("getPackageNameFromFilePath outputs correct package name", {
+    expect_equal(sqlmlutils:::getPackageNameFromFilePath(c('C:\\packages\\binaries\\data.table_1.14.6.zip')), 'data.table')
+    expect_equal(sqlmlutils:::getPackageNameFromFilePath(c('C:\\packages\\binaries\\sqlmlutils_1.2.0.zip')), 'sqlmlutils')
+    expect_equal(sqlmlutils:::getPackageNameFromFilePath(c('C:\\packages\\binaries\\mypackage_metadata_1.14.6.zip')), 'mypackage')
+    expect_equal(sqlmlutils:::getPackageNameFromFilePath(c('C:\\packages\\binaries\\st_1.2.7.zip')), 'st')
+})
+
+#
+# Tests that checking for file existance on invalid filepaths properly fails.
+#
+test_that("areValidFilesPaths fails when files do not exist", {
+    # Using 1 as a default value, functions under test don't use the value
+    # for any calculations
+    topMostPackageFlagAttribute <- 1
+
+    # Generate list of sample file paths that would be provided by a user to sql_install.packages()
+    fileList <- c('C:\\packages\\binaries\\data.table_1.14.6.zip')
+    fileList <- append(fileList, c('C:\\packages\\binaries\\sqlmlutils_1.2.0.zip'))
+    fileList <- append(fileList, c('C:\\packages\\binaries\\st_1.2.7.zip'))
+
+    # As this is a unit test, the sample files in fileList do not actually exist
+    expect_error(sqlmlutils:::areValidFilesPaths(pkgs = fileList))
+})


### PR DESCRIPTION
## Why is this change needed?

- Closes #106 

In order to install a newer version of a package that doesn't have a binary for the desired version of R (i.e. SQL Managed Instance with R 3.5.2), the package must be built from source using the desired version of R. 

For example, the package `data.table`'s most recent version is 1.14.6, but was built using R 4.2.2 which is a higher major.minor version number than R 3.5.2. Therefore, a binary package of `data.table` must be built from source using R 3.5.2 and Rtools35 locally.

As a result of the requirement to build a binary package, I discovered a bug where sqlmlutils did not parse binary package filenames correctly. For the package `data.table`, the regex  `\.|_` was erroneously parsing the package name using the value before the first period OR before the underscore, causing the resolved package name to be `data` instead of `data.table`, causing installation failure on SQL MI.
- The regex rule for period (.) detection is invalid because a period can be part of a package name. R packaging documentation states that a package name 
  > "..should contain only (ASCII) letters, numbers and dot.." [⁠**Reference: cran.r-project.org**](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Creating-R-packages:~:text=The%20mandatory%20%E2%80%98Package%E2%80%99%20field%20gives%20the%20name%20of%20the%20package.%20This%20should%20contain%20only%20(ASCII)%20letters%2C%20numbers%20and%20dot%2C%20have%20at%20least%20two%20characters%20and%20start%20with%20a%20letter%20and%20not%20end%20in%20a%20dot.%20If%20it%20needs%20explaining%2C%20this%20should%20be%20done%20in%20the%20%E2%80%98Description%E2%80%99%20field%20(and%20not%20the%20%E2%80%98Title%E2%80%99%20field).)

## What is this change?

This change fixes the regex to resolve a package name by looking at the character sequence before an underscore `_` in the binary package name. Binary packages on CRAN follow the syntax `<Package Name>_<version>.zip for Windows. An example registry of binary packages for Windows for R 3.5.X can be found on [CRAN](https://cran.rstudio.com/bin/windows/contrib/3.5/)

While the only functionality change in this PR is the regex modification, I also split out the relevant sections of code into smaller, separate helper functions for easier readability and testing.

## How was this tested?
- [x] Unit Tests added
- [x] Manual Integration test successfully installing binary package `data.table_1.14.6.zip` on SQL Managed Instance

## Sample Execution Steps

```R
library(sqlmlutils)
connection <- connectionInfo(server= "tcp:<server>,<port>", database = "<DBName>",uid = "<userName>",pwd= "<pwd>")
pkgPath <- c('C:\\data.table_1.14.6.zip')
sql_install.packages(connectionString = connection, pkgPath, verbose = TRUE, scope="PUBLIC", repos=NULL)
```