### PR TITLE
Remove build warning by updating task to actions/checkout@v4

### DIFF
--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -68,7 +68,7 @@ jobs:
         shell: cmd
 
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Move AirlineTestDB.bak to correct file location for backup command
         run: copy "AirlineTestDB.bak" "C:\Program Files\Microsoft SQL Server\MSSQL16.MSSQLSERVER\MSSQL\Backup\AirlineTestDB.bak"


### PR DESCRIPTION
## Why This Change?

Even though builds are successful, we still get a few warnings that need mitigation due to old versions of github actions used.
![image](https://github.com/microsoft/sqlmlutils/assets/6414189/ee5c1a42-35da-4520-ac8d-0eff59344710)

## What is this change?

- Updates GitHub Actions **actions/checkout** to use v4 as latest.
    ` actions/checkout@v4`
    - per: https://github.com/actions/checkout/releases/tag/v4.1.7
    - See GitHub docs for syntax on referring to "reusable" GitHub Actions tasks: https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow

> You reference reusable workflow files using one of the following syntaxes:
> 
> {owner}/{repo}/.github/workflows/{filename}@{ref} for reusable workflows in public and private repositories.
> ./.github/workflows/{filename} for reusable workflows in the same repository.
> 
> In the first option, {ref} can be a SHA, a release tag, or a branch name. If a release tag and a branch have the same name, the release tag takes precedence over the branch name. Using the commit SHA is the safest option for stability and security. For more information, see "[Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#reusing-third-party-workflows)."
