### PR TITLE
Add SQL Server 2022 workflow contained on runner VM with Python

### DIFF
--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -110,10 +110,26 @@ jobs:
       - name: Configure the R runtime installed for MLS with SQL Server
         run: C:\MLS\R\library\RevoScaleR\rxLibs\x64\RegisterRext.exe /configure /rhome:"C:\MLS\R" /instance:"MSSQLSERVER"
 
-      - name: Download Python installer
+      - name: Install Python for MLS
         run: |
           curl -Lo python-installer.exe https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64.exe
           python-installer.exe /quiet InstallAllUsers=1 TargetDir=C:\MLS\Python
+      
+      - name: Install revoscalepy and dependencies
+        run: |
+          cd C:\MLS\Python
+          python -m pip install -t "C:\MLS\Python\Lib\site-packages" dill numpy==1.22.0 pandas patsy python-dateutil
+          python -m pip install -t "C:\MLS\Python\Lib\site-packages" https://aka.ms/sqlml/python3.10/windows/revoscalepy-10.0.1-py3-none-any.whl
+
+      - name: Grant READ/EXECUTE access to installed libraries
+        run: |
+          icacls "C:\MLS\Python\Lib\site-packages" /grant "NT Service\MSSQLLAUNCHPAD":(OI)(CI)RX /T
+          icacls "C:\MLS\Python\Lib\site-packages" /grant *S-1-15-2-1:(OI)(CI)RX /T
+
+      - name: Configure the Python runtime installed for MLS with SQL Server
+        run: |
+        cd C:\MLS\Python\Lib\site-packages\revoscalepy\rxLibs 
+        .\RegisterRext.exe /configure /pythonhome:"C:\MLS\Python" /instance:"MSSQLSERVER"
 
       - name: Enable External Scripts
         run: sqlcmd -S localhost -U SA -P %dbPassword% -Q "EXEC sp_configure  'external scripts enabled', 1;"
@@ -135,6 +151,12 @@ jobs:
           ',
           @input_data_1 =N'SELECT 1 AS hello'
           WITH RESULT SETS (([hello] int not null));"
+
+      - name: Execute SPEES for Python
+        run: sqlcmd -S localhost -U SA -P %dbPassword% -l 5 -Q "
+          EXEC sp_execute_external_script  @language =N'Python',
+          @script=N'OutputDataSet = InputDataSet;',
+          @input_data_1 =N'SELECT 1 AS hello' WITH RESULT SETS (([hello] int not null));"
 
       - name: Set up R ${{ env.r-version }} Runtime
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -94,8 +94,7 @@ jobs:
       - name: Alter Authorization
         run: sqlcmd -S localhost -U SA -P %dbPassword% -l 5 -Q "
           USE AirlineTestDB;
-          ALTER AUTHORIZATION ON SCHEMA::[db_owner] TO [AirlineUserdbowner];
-          ALTER AUTHORIZATION ON SCHEMA::[db_owner] TO [AirlineUser];"
+          ALTER AUTHORIZATION ON SCHEMA::[db_owner] TO [AirlineUserdbowner]"
 
       # https://learn.microsoft.com/sql/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022?view=sql-server-ver16#setup-r-support
       - name: Install R for MLS
@@ -212,6 +211,6 @@ jobs:
         run: |
           pytest
         env:
-          USER: "AirlineUser"
+          USER: "AirlineUserdbowner"
           PASSWORD: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER: "${{ env.dbPassword }}"

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -130,8 +130,8 @@ jobs:
 
       - name: Configure the Python runtime installed for MLS with SQL Server
         run: |
-        cd C:\MLS\Python\Lib\site-packages\revoscalepy\rxLibs 
-        .\RegisterRext.exe /configure /pythonhome:"C:\MLS\Python" /instance:"MSSQLSERVER"
+          cd C:\MLS\Python\Lib\site-packages\revoscalepy\rxLibs 
+          .\RegisterRext.exe /configure /pythonhome:"C:\MLS\Python" /instance:"MSSQLSERVER"
 
       - name: Enable External Scripts
         run: sqlcmd -S localhost -U SA -P %dbPassword% -Q "EXEC sp_configure  'external scripts enabled', 1;"

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -111,26 +111,24 @@ jobs:
       - name: Configure the R runtime installed for MLS with SQL Server
         run: C:\MLS\R\library\RevoScaleR\rxLibs\x64\RegisterRext.exe /configure /rhome:"C:\MLS\R" /instance:"MSSQLSERVER"
 
-      # Remove any previous installations of Python
-      - name: Uninstall existing Python installations
-        run: |
-          if exist C:\MLS\Python rmdir /S /Q C:\MLS\Python
-          if exist %USERPROFILE%\AppData\Local\Programs\Python\Python310 rmdir /S /Q %USERPROFILE%\AppData\Local\Programs\Python\Python310
-
       # https://learn.microsoft.com/sql/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022?view=sql-server-ver16#setup-python-support
-      - name: Install Python for MLS
-        run: |
-          curl -Lo python-installer.exe https://www.python.org/ftp/python/3.10.2/python-3.10.2-amd64.exe 
-          python-installer.exe /passive InstallAllUsers=1 TargetDir=C:\MLS\Python /log C:\MLS\install.log
+      #- name: Install Python for MLS
+      #  run: |
+      #    curl -Lo python-installer.exe https://www.python.org/ftp/python/3.10.2/python-3.10.2-amd64.exe 
+      #    python-installer.exe /passive InstallAllUsers=1 TargetDir=C:\MLS\Python /log C:\MLS\install.log
       
-      - name: Save Python Logs as artifact
-        if: always()
-        uses: actions/upload-artifact@v4
+      #- name: Save Python Logs as artifact
+      #  if: always()
+      #  uses: actions/upload-artifact@v4
+      #  with:
+      #    name: Python Installation Logs
+      #    path: C:\MLS\install.log
+      #    retention-days: 20
+      - name: Set up Python ${{ env.python-version }}
+        uses: actions/setup-python@v5
         with:
-          name: Python Installation Logs
-          path: C:\MLS\install.log
-          retention-days: 20
-      
+          python-version: ${{ env.python-version }}
+
       - name: Install revoscalepy and dependencies
         run: |
           cd C:\MLS\Python
@@ -197,11 +195,6 @@ jobs:
         env:
           PASSWORD_AIRLINE_USER: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER_DBOWNER: "${{ env.dbPassword }}"
-
-      - name: Set up Python ${{ env.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.python-version }}
 
       - name: Install Python dependencies
         working-directory: ./Python

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -111,19 +111,6 @@ jobs:
       - name: Configure the R runtime installed for MLS with SQL Server
         run: C:\MLS\R\library\RevoScaleR\rxLibs\x64\RegisterRext.exe /configure /rhome:"C:\MLS\R" /instance:"MSSQLSERVER"
 
-      # https://learn.microsoft.com/sql/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022?view=sql-server-ver16#setup-python-support
-      #- name: Install Python for MLS
-      #  run: |
-      #    curl -Lo python-installer.exe https://www.python.org/ftp/python/3.10.2/python-3.10.2-amd64.exe 
-      #    python-installer.exe /passive InstallAllUsers=1 TargetDir=C:\MLS\Python /log C:\MLS\install.log
-      
-      #- name: Save Python Logs as artifact
-      #  if: always()
-      #  uses: actions/upload-artifact@v4
-      #  with:
-      #    name: Python Installation Logs
-      #    path: C:\MLS\install.log
-      #    retention-days: 20
       - name: Set up Python ${{ env.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -156,7 +143,7 @@ jobs:
           timeout /t 5 /nobreak
           net start "MSSQLSERVER"
 
-      - name: Execute SPEES for R
+      - name: Execute sp_execute_external_script for R
         run: sqlcmd -S localhost -U SA -P %dbPassword% -l 5 -Q "
           EXEC sp_execute_external_script  @language =N'R',
           @script=N'
@@ -165,7 +152,7 @@ jobs:
           @input_data_1 =N'SELECT 1 AS hello'
           WITH RESULT SETS (([hello] int not null));"
 
-      - name: Execute SPEES for Python
+      - name: Execute sp_execute_external_script for Python
         run: sqlcmd -S localhost -U SA -P %dbPassword% -l 5 -Q "
           EXEC sp_execute_external_script  @language =N'Python',
           @script=N'OutputDataSet = InputDataSet;',
@@ -214,3 +201,4 @@ jobs:
           USER: "AirlineUserdbowner"
           PASSWORD: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER: "${{ env.dbPassword }}"
+        continue-on-error: true

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -202,3 +202,7 @@ jobs:
         working-directory: ./Python/tests
         run: |
           pytest
+        env:
+          PASSWORD_AIRLINE_USER: "${{ env.dbPassword }}"
+          PASSWORD_AIRLINE_USER_DBOWNER: "${{ env.dbPassword }}"
+

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -132,8 +132,8 @@ jobs:
       - name: Install revoscalepy and dependencies
         working-directory: ${{ env.Python3_ROOT_DIR }}
         run: |
-          python -m pip install -t "C:\MLS\Python\Lib\site-packages" dill numpy==1.22.0 pandas patsy python-dateutil
-          python -m pip install -t "C:\MLS\Python\Lib\site-packages" https://aka.ms/sqlml/python3.10/windows/revoscalepy-10.0.1-py3-none-any.whl
+          python -m pip install -t "${{ env.Python3_ROOT_DIR }}\Lib\site-packages" dill numpy==1.22.0 pandas patsy python-dateutil
+          python -m pip install -t "${{ env.Python3_ROOT_DIR }}\Lib\site-packages" https://aka.ms/sqlml/python3.10/windows/revoscalepy-10.0.1-py3-none-any.whl
 
       - name: Grant READ/EXECUTE access to installed libraries
         run: |
@@ -142,7 +142,7 @@ jobs:
 
       - name: Configure the Python runtime installed for MLS with SQL Server
         working-directory: ${{ env.Python3_ROOT_DIR }}\Lib\site-packages\revoscalepy\rxLibs
-        run: .\RegisterRext.exe /configure /pythonhome:"C:\MLS\Python" /instance:"MSSQLSERVER"
+        run: .\RegisterRext.exe /configure /pythonhome:"${{ env.Python3_ROOT_DIR }}" /instance:"MSSQLSERVER"
 
       - name: Enable External Scripts
         run: sqlcmd -S localhost -U SA -P %dbPassword% -Q "EXEC sp_configure  'external scripts enabled', 1;"

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -111,6 +111,12 @@ jobs:
       - name: Configure the R runtime installed for MLS with SQL Server
         run: C:\MLS\R\library\RevoScaleR\rxLibs\x64\RegisterRext.exe /configure /rhome:"C:\MLS\R" /instance:"MSSQLSERVER"
 
+      # Remove any previous installations of Python
+      - name: Uninstall existing Python installations
+        run: |
+          if exist C:\MLS\Python rmdir /S /Q C:\MLS\Python
+          if exist %USERPROFILE%\AppData\Local\Programs\Python\Python310 rmdir /S /Q %USERPROFILE%\AppData\Local\Programs\Python\Python310
+
       # https://learn.microsoft.com/sql/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022?view=sql-server-ver16#setup-python-support
       - name: Install Python for MLS
         run: |

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -94,7 +94,8 @@ jobs:
       - name: Alter Authorization
         run: sqlcmd -S localhost -U SA -P %dbPassword% -l 5 -Q "
           USE AirlineTestDB;
-          ALTER AUTHORIZATION ON SCHEMA::[db_owner] TO [AirlineUserdbowner]"
+          ALTER AUTHORIZATION ON SCHEMA::[db_owner] TO [AirlineUserdbowner];
+          ALTER AUTHORIZATION ON SCHEMA::[db_owner] TO [AirlineUser];"
 
       # https://learn.microsoft.com/sql/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022?view=sql-server-ver16#setup-r-support
       - name: Install R for MLS
@@ -211,6 +212,6 @@ jobs:
         run: |
           pytest
         env:
-          USER: "AirlineUserdbowner"
+          USER: "AirlineUser"
           PASSWORD: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER: "${{ env.dbPassword }}"

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install Python for MLS
         run: |
           curl -Lo python-installer.exe https://www.python.org/ftp/python/3.10.2/python-3.10.2-amd64.exe 
-          python-installer.exe InstallAllUsers=1 TargetDir=C:\MLS\Python /log C:\MLS\install.log
+          python-installer.exe /passive InstallAllUsers=1 TargetDir=C:\MLS\Python /log C:\MLS\install.log
       
       - name: Save Python Logs as artifact
         if: always()

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -130,20 +130,19 @@ jobs:
           python-version: ${{ env.python-version }}
 
       - name: Install revoscalepy and dependencies
+        working-directory: ${{ env.Python3_ROOT_DIR }}
         run: |
-          cd C:\MLS\Python
           python -m pip install -t "C:\MLS\Python\Lib\site-packages" dill numpy==1.22.0 pandas patsy python-dateutil
           python -m pip install -t "C:\MLS\Python\Lib\site-packages" https://aka.ms/sqlml/python3.10/windows/revoscalepy-10.0.1-py3-none-any.whl
 
       - name: Grant READ/EXECUTE access to installed libraries
         run: |
-          icacls "C:\MLS\Python\Lib\site-packages" /grant "NT Service\MSSQLLAUNCHPAD":(OI)(CI)RX /T
-          icacls "C:\MLS\Python\Lib\site-packages" /grant *S-1-15-2-1:(OI)(CI)RX /T
+          icacls "${{ env.Python3_ROOT_DIR }}\Lib\site-packages" /grant "NT Service\MSSQLLAUNCHPAD":(OI)(CI)RX /T
+          icacls "${{ env.Python3_ROOT_DIR }}\Lib\site-packages" /grant *S-1-15-2-1:(OI)(CI)RX /T
 
       - name: Configure the Python runtime installed for MLS with SQL Server
-        run: |
-          cd C:\MLS\Python\Lib\site-packages\revoscalepy\rxLibs 
-          .\RegisterRext.exe /configure /pythonhome:"C:\MLS\Python" /instance:"MSSQLSERVER"
+        working-directory: ${{ env.Python3_ROOT_DIR }}\Lib\site-packages\revoscalepy\rxLibs
+        run: .\RegisterRext.exe /configure /pythonhome:"C:\MLS\Python" /instance:"MSSQLSERVER"
 
       - name: Enable External Scripts
         run: sqlcmd -S localhost -U SA -P %dbPassword% -Q "EXEC sp_configure  'external scripts enabled', 1;"

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -181,3 +181,24 @@ jobs:
         env:
           PASSWORD_AIRLINE_USER: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER_DBOWNER: "${{ env.dbPassword }}"
+
+      - name: Set up Python ${{ env.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.python-version }}
+
+      - name: Install Python dependencies
+        working-directory: ./Python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8 pytest
+          pip install -r requirements.txt
+
+      - name: Build Python Package
+        working-directory: ./Python
+        run: ./buildandinstall.cmd
+
+      - name: Run pytest
+        working-directory: ./Python/tests
+        run: |
+          pytest

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -96,6 +96,7 @@ jobs:
           USE AirlineTestDB;
           ALTER AUTHORIZATION ON SCHEMA::[db_owner] TO [AirlineUserdbowner]"
 
+      # https://learn.microsoft.com/sql/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022?view=sql-server-ver16#setup-r-support
       - name: Install R for MLS
         run: |
           curl -L -o R-4.2.0-win.exe https://cloud.r-project.org/bin/windows/base/old/4.2.0/R-4.2.0-win.exe
@@ -110,6 +111,7 @@ jobs:
       - name: Configure the R runtime installed for MLS with SQL Server
         run: C:\MLS\R\library\RevoScaleR\rxLibs\x64\RegisterRext.exe /configure /rhome:"C:\MLS\R" /instance:"MSSQLSERVER"
 
+      # https://learn.microsoft.com/sql/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022?view=sql-server-ver16#setup-python-support
       - name: Install Python for MLS
         run: |
           curl -Lo python-installer.exe https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64.exe
@@ -183,7 +185,7 @@ jobs:
           PASSWORD_AIRLINE_USER_DBOWNER: "${{ env.dbPassword }}"
 
       - name: Set up Python ${{ env.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python-version }}
 

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -211,8 +211,6 @@ jobs:
         run: |
           pytest
         env:
-          USER: "AirlineUser"
+          USER: "AirlineUserdbowner"
           PASSWORD: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER: "${{ env.dbPassword }}"
-          PASSWORD_AIRLINE_USER_DBOWNER: "${{ env.dbPassword }}"
-

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -110,6 +110,11 @@ jobs:
       - name: Configure the R runtime installed for MLS with SQL Server
         run: C:\MLS\R\library\RevoScaleR\rxLibs\x64\RegisterRext.exe /configure /rhome:"C:\MLS\R" /instance:"MSSQLSERVER"
 
+      - name: Download Python installer
+        run: |
+          curl -Lo python-installer.exe https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64.exe
+          python-installer.exe /quiet InstallAllUsers=1 TargetDir=C:\MLS\Python
+
       - name: Enable External Scripts
         run: sqlcmd -S localhost -U SA -P %dbPassword% -Q "EXEC sp_configure  'external scripts enabled', 1;"
 

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -114,8 +114,16 @@ jobs:
       # https://learn.microsoft.com/sql/machine-learning/install/sql-machine-learning-services-windows-install-sql-2022?view=sql-server-ver16#setup-python-support
       - name: Install Python for MLS
         run: |
-          curl -Lo python-installer.exe https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64.exe
-          python-installer.exe /quiet InstallAllUsers=1 TargetDir=C:\MLS\Python
+          curl -Lo python-installer.exe https://www.python.org/ftp/python/3.10.2/python-3.10.2-amd64.exe 
+          python-installer.exe InstallAllUsers=1 TargetDir=C:\MLS\Python /log C:\MLS\install.log
+      
+      - name: Save Python Logs as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Python Installation Logs
+          path: C:\MLS\install.log
+          retention-days: 20
       
       - name: Install revoscalepy and dependencies
         run: |

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -211,6 +211,8 @@ jobs:
         run: |
           pytest
         env:
+          USER: "SA"
+          PASSWORD: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER_DBOWNER: "${{ env.dbPassword }}"
 

--- a/.github/workflows/SQL2022.yml
+++ b/.github/workflows/SQL2022.yml
@@ -211,7 +211,7 @@ jobs:
         run: |
           pytest
         env:
-          USER: "SA"
+          USER: "AirlineUser"
           PASSWORD: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER: "${{ env.dbPassword }}"
           PASSWORD_AIRLINE_USER_DBOWNER: "${{ env.dbPassword }}"


### PR DESCRIPTION
This PR adds a new .yaml file which will handle the transition of SQL2022 ML Utils from utilizing Azure Resources by providing support for Python. This aligns SQLMLUtils for SQL Server 2022 with the first phase of the security push.


To demonstrate that the SQL Server 2022 environment is setup correctly we have added a `sp_execute_external_script` task for Python as well, so that we can validate that the GHA is capable of correctly executing an external script in R using the machine learning services.

Link to successful pipeline run: https://github.com/microsoft/sqlmlutils/actions/runs/9898339030/job/27344914128?pr=118